### PR TITLE
Install spyder V3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,9 @@ RUN apt-get install -y tango-test
 # install sardana dependencies
 RUN apt-get install -y python ipython python-h5py python-lxml python-numpy\ 
                        python-nxs python-ply python-pytango python-qt4\ 
-                       python-qwt5-qt4 python-spyderlib python-guiqwt\
-                       pymca
+                       python-qwt5-qt4 python-guiqwt pymca
+# install spyder V3 from pypi
+RUN pip install spyder
 
 # instal virtual monitor
 RUN apt-get install -y xvfb


### PR DESCRIPTION
Taurus 4 drop the support of spyder < 3.0.0

Install spyder V3 from PyPI since it is not available as official package yet.