### PR TITLE
Install graphviz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get install -y python-numpy \
                        python-spyderlib \
                        python-pymca5 \
                        qt4-designer \
-                       python-sphinx-rtd-theme
+                       python-sphinx-rtd-theme \
+                       graphviz
 
 # install some utilities
 RUN apt-get install -y git \


### PR DESCRIPTION
graphviz is needed to support inheritance diagrams when building docs